### PR TITLE
HotFix: WorldGuard non-exist doesn't stop LM now.

### DIFF
--- a/src/main/java/io/github/lokka30/levelledmobs/LevelledMobs.java
+++ b/src/main/java/io/github/lokka30/levelledmobs/LevelledMobs.java
@@ -1,11 +1,7 @@
 package io.github.lokka30.levelledmobs;
 
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.StringFlag;
-import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
-import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import de.leonhard.storage.LightningBuilder;
 import de.leonhard.storage.internal.FlatFile;
 import de.leonhard.storage.internal.exception.LightningValidationException;
@@ -15,6 +11,7 @@ import io.github.lokka30.levelledmobs.listeners.LMobDamage;
 import io.github.lokka30.levelledmobs.listeners.LMobDeath;
 import io.github.lokka30.levelledmobs.listeners.LMobSpawn;
 import io.github.lokka30.levelledmobs.utils.LogLevel;
+import io.github.lokka30.levelledmobs.utils.ManageWorldGuard;
 import io.github.lokka30.levelledmobs.utils.UpdateChecker;
 import io.github.lokka30.levelledmobs.utils.Utils;
 import org.bstats.bukkit.Metrics;
@@ -173,39 +170,7 @@ public class LevelledMobs extends JavaPlugin {
         worldguard = getServer().getPluginManager().getPlugin("WorldGuard") != null;
 
         if (worldguard) {
-            FlagRegistry freg = WorldGuard.getInstance().getFlagRegistry();
-            try {
-                StateFlag allowflag;
-                StringFlag minflag, maxflag;
-
-                allowflag = new StateFlag("CustomLevelFlag", false);
-                minflag = new StringFlag("MinLevelFlag", "-1");
-                maxflag = new StringFlag("MaxLevelFlag", "-1");
-
-                freg.register(allowflag);
-                freg.register(minflag);
-                freg.register(maxflag);
-
-                allowlevelflag = allowflag;
-                minlevelflag = minflag;
-                maxlevelflag = maxflag;
-            } catch (FlagConflictException e) {
-                Flag<?> allow = freg.get("CustonmLevelFlag");
-                Flag<?> min = freg.get("MinLevelFlag");
-                Flag<?> max = freg.get("MaxLevelFlag");
-
-                if (min instanceof StringFlag) {
-                    minlevelflag = (StringFlag) min;
-                }
-
-                if (max instanceof StringFlag) {
-                    maxlevelflag = (StringFlag) max;
-                }
-
-                if (allow instanceof StateFlag) {
-                    allowlevelflag = (StateFlag) allow;
-                }
-            }
+            ManageWorldGuard.registerFlags();
         }
     }
 

--- a/src/main/java/io/github/lokka30/levelledmobs/listeners/LMobDeath.java
+++ b/src/main/java/io/github/lokka30/levelledmobs/listeners/LMobDeath.java
@@ -1,8 +1,6 @@
 package io.github.lokka30.levelledmobs.listeners;
 
-import io.github.lokka30.levelledmobs.LevelManager;
 import io.github.lokka30.levelledmobs.LevelledMobs;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;

--- a/src/main/java/io/github/lokka30/levelledmobs/listeners/LMobSpawn.java
+++ b/src/main/java/io/github/lokka30/levelledmobs/listeners/LMobSpawn.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static io.github.lokka30.levelledmobs.utils.ManageWorldGuard.*;
 import static io.github.lokka30.levelledmobs.utils.Utils.*;
 
 public class LMobSpawn implements Listener {
@@ -33,7 +34,7 @@ public class LMobSpawn implements Listener {
             LivingEntity ent = e.getEntity(); //The entity that was just spawned.
 
             //Check settings for spawn distance levelling and choose levelling method accordingly.
-            if(checkRegionFlags(ent)) {
+            if(instance.worldguard && checkRegionFlags(ent)) {
                 level = generateRegionLevel(ent);
             } else if (instance.settings.get("spawn-distance-levelling.active", false)) {
                 level = generateLevelByDistance(ent);
@@ -175,26 +176,13 @@ public class LMobSpawn implements Listener {
     	return finallevel;
     }
 
-    //Generate level based on WorldGuard region flags.
-    private int generateRegionLevel(LivingEntity ent) {
-        //Sorted region array, highest priority comes last.
-        ProtectedRegion[] regions = sortRegionsByPriority(getRegionSet(ent));
-
+    private int generateRegionLevel(LivingEntity ent){
         //Fallback values
         int minlevel = instance.settings.get("fine-tuning.min-level", 1);
         int maxlevel = instance.settings.get("fine-tuning.max-level", 10);
 
-        //Set min. max. level to flag values
-        for (ProtectedRegion region : regions) {
-            if (isInteger(region.getFlag(LevelledMobs.minlevelflag)))
-                minlevel = Math.max(Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))), 0);
-            if (isInteger(region.getFlag(LevelledMobs.maxlevelflag)))
-                maxlevel = Math.max(Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.maxlevelflag))), 0);
-        }
+        int[] levels = getRegionLevel(ent, minlevel, maxlevel);
 
-        return minlevel + Math.round(new Random().nextFloat() * (maxlevel - minlevel));
+        return levels[0] + Math.round(new Random().nextFloat() * (levels[1] - levels[0]));
     }
-
-
-
 }

--- a/src/main/java/io/github/lokka30/levelledmobs/utils/ManageWorldGuard.java
+++ b/src/main/java/io/github/lokka30/levelledmobs/utils/ManageWorldGuard.java
@@ -1,0 +1,137 @@
+package io.github.lokka30.levelledmobs.utils;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.StringFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import io.github.lokka30.levelledmobs.LevelledMobs;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.*;
+
+import static io.github.lokka30.levelledmobs.LevelledMobs.getInstance;
+import static io.github.lokka30.levelledmobs.utils.Utils.isInteger;
+
+public class ManageWorldGuard {
+    public static void registerFlags(){
+        FlagRegistry freg = WorldGuard.getInstance().getFlagRegistry();
+        try {
+            StateFlag allowflag;
+            StringFlag minflag, maxflag;
+
+            allowflag = new StateFlag("CustomLevelFlag", false);
+            minflag = new StringFlag("MinLevelFlag", "-1");
+            maxflag = new StringFlag("MaxLevelFlag", "-1");
+
+            freg.register(allowflag);
+            freg.register(minflag);
+            freg.register(maxflag);
+
+            LevelledMobs.allowlevelflag = allowflag;
+            LevelledMobs.minlevelflag = minflag;
+            LevelledMobs.maxlevelflag = maxflag;
+        } catch (FlagConflictException e) {
+            Flag<?> allow = freg.get("CustonmLevelFlag");
+            Flag<?> min = freg.get("MinLevelFlag");
+            Flag<?> max = freg.get("MaxLevelFlag");
+
+            if (min instanceof StringFlag) {
+                LevelledMobs.minlevelflag = (StringFlag) min;
+            }
+
+            if (max instanceof StringFlag) {
+                LevelledMobs.maxlevelflag = (StringFlag) max;
+            }
+
+            if (allow instanceof StateFlag) {
+                LevelledMobs.allowlevelflag = (StateFlag) allow;
+            }
+        }
+    }
+
+    //Get all regions at an Entities' location.
+    public static ApplicableRegionSet getRegionSet(LivingEntity ent){
+        Location loc = ent.getLocation();
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionManager regions = container.get(BukkitAdapter.adapt(ent.getWorld()));
+
+        return Objects.requireNonNull(regions).getApplicableRegions(BlockVector3.at(loc.getX(),loc.getY(),loc.getZ()));
+    }
+
+    //Sorts a RegionSet by priority, lowest to highest.
+    public static ProtectedRegion[] sortRegionsByPriority(ApplicableRegionSet regset){
+        ProtectedRegion[] regionarray = new ProtectedRegion[0];
+        List<ProtectedRegion> regionList = new ArrayList<>();
+
+        if(regset.size() == 0)
+            return regionarray;
+        else if (regset.size() == 1) {
+            regionarray = new ProtectedRegion[1];
+            return regset.getRegions().toArray(regionarray);
+        }
+
+        for(ProtectedRegion r : regset){
+            regionList.add(r);
+        }
+
+        regionList.sort(Comparator.comparingInt(ProtectedRegion::getPriority));
+
+        return regionList.toArray(regionarray);
+    }
+
+    //Check if region is applicable for region levelling.
+    public static boolean checkRegionFlags(LivingEntity ent) {
+        boolean minbool = false;
+        boolean maxbool = false;
+        boolean customlevelbool = false;
+
+        //Check if WorldGuard-plugin exists
+        if(!getInstance().worldguard)
+            return false;
+
+        //Sorted region array, highest priority comes last.
+        ProtectedRegion[] regions = sortRegionsByPriority(getRegionSet(ent));
+
+        //Check region flags on integrity.
+        for (ProtectedRegion region : regions) {
+            if (isInteger(region.getFlag(LevelledMobs.minlevelflag)))
+                if (Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))) > -1)
+                    minbool = true;
+            if (isInteger(region.getFlag(LevelledMobs.maxlevelflag)))
+                if (Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.maxlevelflag))) > Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))))
+                    maxbool = true;
+            if (region.getFlag(LevelledMobs.allowlevelflag) == StateFlag.State.ALLOW)
+                customlevelbool = true;
+            else if (region.getFlag(LevelledMobs.allowlevelflag) == StateFlag.State.DENY)
+                customlevelbool = false;
+        }
+
+        return minbool && maxbool && customlevelbool;
+    }
+
+
+    //Generate level based on WorldGuard region flags.
+    public static int[] getRegionLevel(LivingEntity ent, int minlevel, int maxlevel) {
+        //Sorted region array, highest priority comes last.
+        ProtectedRegion[] regions = sortRegionsByPriority(getRegionSet(ent));
+
+        //Set min. max. level to flag values
+        for (ProtectedRegion region : regions) {
+            if (isInteger(region.getFlag(LevelledMobs.minlevelflag)))
+                minlevel = Math.max(Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))), 0);
+            if (isInteger(region.getFlag(LevelledMobs.maxlevelflag)))
+                maxlevel = Math.max(Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.maxlevelflag))), 0);
+        }
+
+        return new int[]{minlevel, maxlevel};
+    }
+}

--- a/src/main/java/io/github/lokka30/levelledmobs/utils/Utils.java
+++ b/src/main/java/io/github/lokka30/levelledmobs/utils/Utils.java
@@ -1,24 +1,5 @@
 package io.github.lokka30.levelledmobs.utils;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import com.sk89q.worldguard.protection.regions.RegionContainer;
-import io.github.lokka30.levelledmobs.LevelledMobs;
-import org.bukkit.Location;
-import org.bukkit.entity.LivingEntity;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-
-import static io.github.lokka30.levelledmobs.LevelledMobs.getInstance;
-
 public class Utils {
     public static String getRecommendedServerVersion() {
         return "1.15";
@@ -83,63 +64,5 @@ public class Utils {
         return true;
     }
 
-    //Get all regions at an Entities' location.
-    public static ApplicableRegionSet getRegionSet(LivingEntity ent){
-        Location loc = ent.getLocation();
-        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
-        RegionManager regions = container.get(BukkitAdapter.adapt(ent.getWorld()));
 
-        return Objects.requireNonNull(regions).getApplicableRegions(BlockVector3.at(loc.getX(),loc.getY(),loc.getZ()));
-    }
-
-    //Sorts a RegionSet by priority, lowest to highest.
-    public static ProtectedRegion[] sortRegionsByPriority(ApplicableRegionSet regset){
-        ProtectedRegion[] regionarray = new ProtectedRegion[0];
-        List<ProtectedRegion> regionList = new ArrayList<>();
-
-        if(regset.size() == 0)
-            return regionarray;
-        else if (regset.size() == 1) {
-            regionarray = new ProtectedRegion[1];
-            return regset.getRegions().toArray(regionarray);
-        }
-
-        for(ProtectedRegion r : regset){
-            regionList.add(r);
-        }
-
-        regionList.sort(Comparator.comparingInt(ProtectedRegion::getPriority));
-
-        return regionList.toArray(regionarray);
-    }
-
-    //Check if region is applicable for region levelling.
-    public static boolean checkRegionFlags(LivingEntity ent) {
-        boolean minbool = false;
-        boolean maxbool = false;
-        boolean customlevelbool = false;
-
-        //Check if WorldGuard-plugin exists
-        if(!getInstance().worldguard)
-            return false;
-
-        //Sorted region array, highest priority comes last.
-        ProtectedRegion[] regions = sortRegionsByPriority(getRegionSet(ent));
-
-        //Check region flags on integrity.
-        for (ProtectedRegion region : regions) {
-            if (isInteger(region.getFlag(LevelledMobs.minlevelflag)))
-                if (Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))) > -1)
-                    minbool = true;
-            if (isInteger(region.getFlag(LevelledMobs.maxlevelflag)))
-                if (Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.maxlevelflag))) > Integer.parseInt(Objects.requireNonNull(region.getFlag(LevelledMobs.minlevelflag))))
-                    maxbool = true;
-            if (region.getFlag(LevelledMobs.allowlevelflag) == StateFlag.State.ALLOW)
-                customlevelbool = true;
-            else if (region.getFlag(LevelledMobs.allowlevelflag) == StateFlag.State.DENY)
-                customlevelbool = false;
-        }
-
-        return minbool && maxbool && customlevelbool;
-    }
 }


### PR DESCRIPTION
I think I fixed it. Now all methods that access any WG related classes are located in ManageWorldGuard.java

No more hangs when it isn't existing.