### PR TITLE
v3.4.1 b625

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>me.lokka30</groupId>
     <artifactId>LevelledMobs</artifactId>
-    <version>3.4.0 b624</version>
+    <version>3.4.1 b625</version>
     <packaging>jar</packaging>
 
     <name>LevelledMobs</name>

--- a/src/main/java/me/lokka30/levelledmobs/customdrops/CustomDropsHandler.java
+++ b/src/main/java/me/lokka30/levelledmobs/customdrops/CustomDropsHandler.java
@@ -551,6 +551,8 @@ public class CustomDropsHandler {
 
     private boolean hasReachedChunkKillLimit(final @NotNull LivingEntityWrapper lmEntity){
         final int maximumDeathInChunkThreshold = main.rulesManager.getMaximumDeathInChunkThreshold(lmEntity);
+        if (maximumDeathInChunkThreshold <= 0) return false;
+
         return lmEntity.chunkKillcount >= maximumDeathInChunkThreshold;
     }
 


### PR DESCRIPTION
* fixed custom drops showing chunk kill count reached even when maximum-death-in-chunk-threshold is set to 0